### PR TITLE
fix: exclude .git and fix self-exclusion in ls-todo

### DIFF
--- a/scripts/ls-todo.sh
+++ b/scripts/ls-todo.sh
@@ -63,7 +63,8 @@ function main() {
 	grep \
 		--recursive \
 		--line-number \
-		--exclude=./scripts/ls-todo.sh \
+		--exclude="$CURRENT_SOURCE_FILE_NAME" \
+		--exclude-dir=.git \
 		--extended-regexp 'TODO:|FIXME:' .
 }
 


### PR DESCRIPTION
The recursive grep descended into .git, surfacing spurious TODO/FIXME
matches from packfiles and other objects. Add --exclude-dir=.git to
skip the whole directory.

Also fix the --exclude pattern for the script itself: grep matches
--exclude against the file basename, so "./scripts/ls-todo.sh" never
matched. Use "ls-todo.sh" instead.

This commit message is generated by LLM, it might be wrong.

Assisted-by: Claude:glm-5.1
