### PR TITLE
ci: allow manual workflow triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 0 * * 0' # Runs every Sunday at midnight UTC
+  workflow_dispatch:
 
 jobs:
   generic:


### PR DESCRIPTION
Add `workflow_dispatch` to `ci.yaml` so the pipeline can be run on demand from the Actions tab, aligning the template with the recommended layout in black-desk/workflows.

No behavioral change to existing push/PR/schedule triggers.